### PR TITLE
Fix incompatibility with Omnisearch

### DIFF
--- a/scripts/pdf-pager.mjs
+++ b/scripts/pdf-pager.mjs
@@ -52,7 +52,7 @@ Hooks.once('ready', async () => {
 // JournalEntryPage#toc only works when type === 'text'
 function JournalEntryPage_toc(wrapped) {
     if (this.type !== 'pdf') return wrapped();
-    if (!this._toc) this._toc = JSON.parse(this.getFlag(PDFCONFIG.MODULE_NAME, PDFCONFIG.FLAG_TOC));
+    if (!this._toc) this._toc = JSON.parse(this.getFlag(PDFCONFIG.MODULE_NAME, PDFCONFIG.FLAG_TOC) ?? "{}");
     return this._toc;
 }
 


### PR DESCRIPTION
(Patched line from ripper93)

If `this.getFlag(PDFCONFIG.MODULE_NAME, PDFCONFIG.FLAG_TOC)` is undefined, the function will error 
(which makes Omnisearch not be able to read TOC content to use it in searches.)